### PR TITLE
Update SSH/SCP command snippets to use generic user

### DIFF
--- a/website/pages/challenges/challengeDisplayDocker.php
+++ b/website/pages/challenges/challengeDisplayDocker.php
@@ -170,8 +170,8 @@ if ($isRunning) {
 
 // Dynamic SSH/SCP snippets (live port if running, placeholder otherwise)
 $sshPort = $isRunning && $port ? (string)$port : "<PORT>";
-$sshCmd  = "ssh -p {$sshPort} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null RoboCop@{$ipAddress}";
-$scpCmd  = "scp -P {$sshPort} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null RoboCop@{$ipAddress}:/home/RoboCop/Alarm.png ./(Filename and type)";
+$sshCmd  = "ssh -p {$sshPort} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null (User)@{$ipAddress}";
+$scpCmd  = "scp -P {$sshPort} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null (User)@{$ipAddress}:/home/(User)/Alarm.png ./(Filename and type)";
 ?>
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
Replaced hardcoded 'RoboCop' username in SSH and SCP command examples with a generic '(User)' placeholder to improve clarity and adaptability for different users.