### PR TITLE
Fix file download button to check for non-empty files

### DIFF
--- a/website/pages/challenges/challengeDisplay.php
+++ b/website/pages/challenges/challengeDisplay.php
@@ -121,7 +121,7 @@ loadChallengeData();
             <tr>
                 <td class="text-start"><?= nl2br(makeLinksClickable(htmlspecialchars($challengeText))) ?></td>
                 <td>
-                    <?php if ($files): ?>
+                    <?php if (!empty($files)): ?>
                         <a href="<?= htmlspecialchars($files) ?>" download class="btn btn-primary btn-sm">
                             Download File
                         </a>

--- a/website/pages/challenges/challengeDisplayDocker.php
+++ b/website/pages/challenges/challengeDisplayDocker.php
@@ -250,7 +250,7 @@ $scpCmd  = "scp -P {$sshPort} -o StrictHostKeyChecking=no -o UserKnownHostsFile=
             <tr>
                 <td class="text-start"><?= nl2br(htmlspecialchars($challengeText)) ?></td>
                 <td>
-                    <?php if ($files): ?>
+                    <?php if (!empty($files)): ?>
                         <a href="<?= htmlspecialchars($files) ?>" download class="btn btn-primary btn-sm">
                             Download File
                         </a>


### PR DESCRIPTION
Updated the file download button logic in challengeDisplay.php and challengeDisplayDocker.php to only show the button when the $files variable is not empty, preventing display of the button when no file is available.